### PR TITLE
#2 Update to version 2.0.1 and convert to be npm based

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WebSharper.Remarkable
 
-WebSharper Extension for remarkable 1.7.1
+WebSharper Extension for remarkable 2.0.1+
 
 * [Source Repository](https://github.com/intellifactory/websharper.remarkable)

--- a/WebSharper.Remarkable.RenderingTest/Client.fs
+++ b/WebSharper.Remarkable.RenderingTest/Client.fs
@@ -37,12 +37,12 @@ module Client =
         remarkableConfig.XhtmlOut <- false
         remarkableConfig.Breaks <- false
         remarkableConfig.LangPrefix <- "language-"
-        remarkableConfig.Linkify <- true
         remarkableConfig.LinkTarget <- ""
         remarkableConfig.Typographer <- false
         remarkableConfig.Quotes <- "'����'"
 
         let md = new Remarkable.Remarkable(remarkableConfig)
+        
         let rvInput = Var.Create ""
         div [] [
             h1 [] [text "WebSharper.Remarkable extension sample page"]

--- a/WebSharper.Remarkable.RenderingTest/index.html
+++ b/WebSharper.Remarkable.RenderingTest/index.html
@@ -9,11 +9,11 @@
         /* Don't show the not-yet-loaded templates */
         [ws-template], [ws-children-template] { display: none; }
     </style>
-    <script type="text/javascript" src="Content/WebSharper.Remarkable.RenderingTest.head.js"></script>
+    <script type="module" src="Content/WebSharper.Remarkable.RenderingTest.head.js"></script>
 </head>
 <body>
     <div id="main">
     </div>
-    <script type="text/javascript" src="Content/WebSharper.Remarkable.RenderingTest.min.js"></script>
+    <script type="module" src="Content/WebSharper.Remarkable.RenderingTest.min.js"></script>
 </body>
 </html>

--- a/WebSharper.Remarkable.RenderingTest/package-lock.json
+++ b/WebSharper.Remarkable.RenderingTest/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "websharper.remarkable.renderingtest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "websharper.remarkable.renderingtest",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "remarkable": "^2.0.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/autolinker": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+      "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    }
+  }
+}

--- a/WebSharper.Remarkable.RenderingTest/package.json
+++ b/WebSharper.Remarkable.RenderingTest/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "websharper.remarkable.renderingtest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "remarkable": "^2.0.1"
+  }
+}

--- a/WebSharper.Remarkable/WebSharper.Remarkable.fsproj
+++ b/WebSharper.Remarkable/WebSharper.Remarkable.fsproj
@@ -1,13 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <WebSharperProject>Extension</WebSharperProject>
+    <WebSharperProject>binding</WebSharperProject>
     <WebSharperSourceMap>false</WebSharperSourceMap>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Product>WebSharper.Remarkable 2.0+</Product>
+    <Title>https://github.com/dotnet-websharper/remarkable/</Title>
+    <Company>IntelliFactory</Company>
+    <Copyright>(c) 2023 IntelliFactory</Copyright>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.fs" />
   </ItemGroup>
+  <PropertyGroup>
+	<NpmDependencies>
+	  <NpmPackage Name="remarkable" Version="gt= 2.0.1 lt 3.0.0" ResolutionStrategy="Max" />
+	</NpmDependencies>
+  </PropertyGroup>
   <Import Project="..\paket-files\wsbuild\github.com\dotnet-websharper\build-script\WebSharper.Fake.targets" Condition="Exists('..\paket-files\wsbuild\github.com\dotnet-websharper\build-script\WebSharper.Fake.targets')" />
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/nuget/WebSharper.Remarkable.paket.template
+++ b/nuget/WebSharper.Remarkable.paket.template
@@ -10,7 +10,7 @@ licenseUrl https://github.com/dotnet-websharper/remarkable/blob/master/LICENSE.m
 iconUrl https://github.com/dotnet-websharper/core/raw/websharper50/tools/WebSharper.png
 projectUrl https://github.com/dotnet-websharper/remarkable
 description
-    WebSharper Extension for remarkable 1.7.1
+    WebSharper Extension for remarkable 2.0.1+
 tags
     Web JavaScript F# C#
 files


### PR DESCRIPTION
- Linkify removed (moved to a plugin in the new js version), TODO implement that plugin
- uses NPM in fsproj instead of direct CDN resource in binding